### PR TITLE
feat: add Pitchout spectator and reconnect continuity

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
           # Keep cross-repository builds reproducible. Update this SHA alongside
           # coordinated CookieDough API changes; the repository variable is an
           # explicit escape hatch for compatibility testing.
-          ref: ${{ vars.COOKIE_DOUGH_REF || 'aa65641843ad947a145e2a5e4d2350b4c5bf6cad' }}
+          ref: ${{ vars.COOKIE_DOUGH_REF || '76d2b591e811eacfd312815044b16c5e599f09aa' }}
           path: CookieDough
 
       - name: Set up Java 25

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ repositories {
 dependencies {
     implementation project(path: ':CookieDough', configuration: 'shadow')
     compileOnly 'jakarta.persistence:jakarta.persistence-api:3.2.0'
-    compileOnly 'io.papermc.paper:paper-api:26.1.2.build.74-stable'
+    compileOnly 'io.papermc.paper:paper-api:26.2.build.116-stable'
     compileOnly 'org.geysermc.cumulus:cumulus:1.1.2'
-    testImplementation 'io.papermc.paper:paper-api:26.1.2.build.74-stable'
+    testImplementation 'io.papermc.paper:paper-api:26.2.build.116-stable'
     testImplementation 'org.geysermc.cumulus:cumulus:1.1.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.12.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.2'

--- a/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
+++ b/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
@@ -73,6 +73,7 @@ public class PitchoutGame extends Game implements ReconnectableGame {
     private int runningSeconds;
     private final int maximumRunningSeconds;
     private boolean timeoutWarningSent;
+    private boolean reconnectExpiryBatch;
 
     public PitchoutGame(UUID gameId, GameMap preparedMap) {
         super("Pitchout", gameId);
@@ -168,14 +169,9 @@ public class PitchoutGame extends Game implements ReconnectableGame {
     }
 
     @Override
-    protected boolean teleportToSpectator(CookiePlayer cookiePlayer) {
-        if (map == null || map.getWorld() == null) return false;
-        Player player = cookiePlayer.getPlayer();
-        Location destination = map.getWaitingLobbyLocation().clone().add(0.0, 8.0, 0.0);
-        if (!destination.getChunk().load() || !player.teleport(destination)) return false;
-        cookiePlayer.resetPlayer();
-        player.setGameMode(GameMode.SPECTATOR);
-        return true;
+    protected Location spectatorDestination(CookiePlayer cookiePlayer) {
+        return map == null || map.getWorld() == null
+                ? null : map.getWaitingLobbyLocation().clone().add(0.0, 8.0, 0.0);
     }
 
     @Override
@@ -700,7 +696,7 @@ public class PitchoutGame extends Game implements ReconnectableGame {
         reconnectSnapshots.remove(playerId);
 
         scoreboard.remove(player.getPlayer());
-        if (getState() == GameState.RUNNING) {
+        if (getState() == GameState.RUNNING && !reconnectExpiryBatch) {
             checkForWinner();
         } else if (getState() == GameState.OPEN) {
             participantIds.remove(player.getPlayer().getUniqueId());
@@ -738,13 +734,19 @@ public class PitchoutGame extends Game implements ReconnectableGame {
 
     private void expireReconnectReservations() {
         long now = System.currentTimeMillis();
-        for (UUID playerId : List.copyOf(disconnectedAt.keySet())) {
-            Long disconnected = disconnectedAt.get(playerId);
-            if (disconnected == null || now - disconnected <= RECONNECT_GRACE_MILLIS) continue;
-            CookiePlayer previous = playerLives.keySet().stream()
-                    .filter(player -> player.getPlayer().getUniqueId().equals(playerId)).findFirst().orElse(null);
-            if (previous != null) removePlayer(previous, "reconnect_expired");
+        List<UUID> expired = ReconnectExpiryPolicy.expired(disconnectedAt, now, RECONNECT_GRACE_MILLIS);
+        if (expired.isEmpty()) return;
+        reconnectExpiryBatch = true;
+        try {
+            for (UUID playerId : expired) {
+                CookiePlayer previous = playerLives.keySet().stream()
+                        .filter(player -> player.getPlayer().getUniqueId().equals(playerId)).findFirst().orElse(null);
+                if (previous != null) removePlayer(previous, "reconnect_expired");
+            }
+        } finally {
+            reconnectExpiryBatch = false;
         }
+        if (getState() == GameState.RUNNING) checkForWinner();
     }
 
     public int getPlayerLives(CookiePlayer player) {

--- a/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
+++ b/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
@@ -138,7 +138,7 @@ public class PitchoutGame extends Game implements ReconnectableGame {
 
         player.resetPlayer();
         if (getState() == GameState.OPEN) {
-            player.getPlayer().teleport(map.getWaitingLobbyLocation());
+            teleportPlayerSafely(player.getPlayer(), map.getWaitingLobbyLocation());
             return;
         }
 
@@ -158,7 +158,7 @@ public class PitchoutGame extends Game implements ReconnectableGame {
         player.getPlayer().getInventory().setItem(8, arrow);
         Location spawnLocation = initialSpawns.getOrDefault(
                 player.getPlayer().getUniqueId(), map.getRandomSpawnLocation());
-        player.getPlayer().teleport(spawnLocation);
+        teleportPlayerSafely(player.getPlayer(), spawnLocation);
         player.getPlayer().setFallDistance(0);
         player.setState(PlayerState.IN_GAME);
     }

--- a/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
+++ b/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
@@ -613,6 +613,14 @@ public class PitchoutGame extends Game implements ReconnectableGame {
             endSequenceTask.cancel();
             endSequenceTask = null;
         }
+        if (!ejectOwnedPlayersToLobby()) {
+            cleanupStarted = false;
+            Pitchout.getInstance().getLogger().warning(
+                    "Deferring Pitchout map cleanup until every player reaches the lobby: " + getGameId());
+            endSequenceTask = Bukkit.getScheduler().runTaskLater(
+                    Pitchout.getInstance(), this::cleanupGameResources, 20L);
+            return;
+        }
 
         if (MapManager.inGamePlayerListener != null) {
             MapManager.inGamePlayerListener.clearGameState(getGameId());
@@ -625,7 +633,6 @@ public class PitchoutGame extends Game implements ReconnectableGame {
                     "Failed while draining Pitchout players; map cleanup will continue: " + exception.getMessage());
         }
 
-        ejectSpectatorsToLobby();
         try {
             if (map != null && !MapManager.unloadMap(getGameId().toString())) {
                 Pitchout.getInstance().getLogger().warning(

--- a/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
+++ b/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
@@ -285,9 +285,10 @@ public class PitchoutGame extends Game implements ReconnectableGame {
             gameState = "game.ended";
         }
 
-        for (CookiePlayer player : getPlayers()) {
+        for (CookiePlayer player : matchViewers()) {
             Player bukkitPlayer = player.getPlayer();
-            boolean isSpectator = bukkitPlayer.getGameMode() == GameMode.SPECTATOR;
+            boolean isSpectator = bukkitPlayer.getGameMode() == GameMode.SPECTATOR
+                    || isExternalSpectator(bukkitPlayer.getUniqueId());
             String localizedState = countdownSeconds == null
                     ? LocaleManager.getMessage(gameState, bukkitPlayer.locale())
                     : gameState.startsWith("pitchout.")
@@ -377,7 +378,7 @@ public class PitchoutGame extends Game implements ReconnectableGame {
     }
 
     private void showOutcomeTitles(CookiePlayer winner) {
-        for (CookiePlayer cookiePlayer : getPlayers()) {
+        for (CookiePlayer cookiePlayer : matchViewers()) {
             Player player = cookiePlayer.getPlayer();
             if (winner == null) {
                 sendGameTitle(player,
@@ -385,6 +386,12 @@ public class PitchoutGame extends Game implements ReconnectableGame {
                                 NamedTextColor.YELLOW, TextDecoration.BOLD),
                         Component.text(Pitchout.message(player, "pitchout.outcome.draw.subtitle"),
                                 NamedTextColor.GRAY));
+            } else if (isExternalSpectator(player.getUniqueId())) {
+                sendGameTitle(player,
+                        Component.text(LocaleManager.getMessage("game.ended", player.locale()),
+                                NamedTextColor.GOLD, TextDecoration.BOLD),
+                        Component.text(Pitchout.message(player, "pitchout.outcome.defeat.subtitle",
+                                winner.getPlayer().getName()), NamedTextColor.GRAY));
             } else if (player.getUniqueId().equals(winner.getPlayer().getUniqueId())) {
                 sendGameTitle(player,
                         Component.text(Pitchout.message(player, "pitchout.outcome.victory"),
@@ -399,6 +406,17 @@ public class PitchoutGame extends Game implements ReconnectableGame {
                                 winner.getPlayer().getName()), NamedTextColor.GRAY));
             }
         }
+    }
+
+    private List<CookiePlayer> matchViewers() {
+        Map<UUID, CookiePlayer> viewers = new LinkedHashMap<>();
+        for (CookiePlayer participant : getPlayers()) {
+            viewers.put(participant.getPlayer().getUniqueId(), participant);
+        }
+        for (CookiePlayer spectator : getSpectators()) {
+            viewers.putIfAbsent(spectator.getPlayer().getUniqueId(), spectator);
+        }
+        return List.copyOf(viewers.values());
     }
 
     private void tryPersistOutcomeAndRewards(CookiePlayer winner, boolean notifyPlayers) {

--- a/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
+++ b/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
@@ -32,6 +32,8 @@ import com.cookiebuild.cookiedough.CookieDough;
 import com.cookiebuild.cookiedough.game.Game;
 import com.cookiebuild.cookiedough.game.GameManager;
 import com.cookiebuild.cookiedough.game.GameState;
+import com.cookiebuild.cookiedough.game.PlayerActivitySnapshot;
+import com.cookiebuild.cookiedough.game.ReconnectableGame;
 import com.cookiebuild.cookiedough.lobby.LobbyManager;
 import com.cookiebuild.cookiedough.lobby.LobbyScoreboard;
 import com.cookiebuild.cookiedough.model.Match;
@@ -49,11 +51,14 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.title.Title;
 
-public class PitchoutGame extends Game {
+public class PitchoutGame extends Game implements ReconnectableGame {
+    private static final long RECONNECT_GRACE_MILLIS = Duration.ofSeconds(60).toMillis();
     private static final int MAX_LIVES = 5;
     private GameMap map;
     private final HashMap<CookiePlayer, Integer> playerLives = new HashMap<>();
     private final Map<UUID, Location> initialSpawns = new HashMap<>();
+    private final Map<UUID, Long> disconnectedAt = new HashMap<>();
+    private final Map<UUID, PlayerActivitySnapshot> reconnectSnapshots = new HashMap<>();
     private final PitchoutScoreboard scoreboard = new PitchoutScoreboard();
     private final PitchoutStats stats = new PitchoutStats();
     private BukkitTask endSequenceTask;
@@ -158,6 +163,22 @@ public class PitchoutGame extends Game {
     }
 
     @Override
+    public boolean supportsSpectating() {
+        return true;
+    }
+
+    @Override
+    protected boolean teleportToSpectator(CookiePlayer cookiePlayer) {
+        if (map == null || map.getWorld() == null) return false;
+        Player player = cookiePlayer.getPlayer();
+        Location destination = map.getWaitingLobbyLocation().clone().add(0.0, 8.0, 0.0);
+        if (!destination.getChunk().load() || !player.teleport(destination)) return false;
+        cookiePlayer.resetPlayer();
+        player.setGameMode(GameMode.SPECTATOR);
+        return true;
+    }
+
+    @Override
     public boolean isGameEnded() {
         return this.getState() == GameState.FINISHED;
     }
@@ -178,6 +199,7 @@ public class PitchoutGame extends Game {
         updateGameInfo();
 
         if (getState() == GameState.RUNNING) {
+            expireReconnectReservations();
             runningSeconds++;
             int warningSeconds = Math.min(60, maximumRunningSeconds / 3);
             if (!timeoutWarningSent && runningSeconds >= maximumRunningSeconds - warningSeconds) {
@@ -589,6 +611,7 @@ public class PitchoutGame extends Game {
                     "Failed while draining Pitchout players; map cleanup will continue: " + exception.getMessage());
         }
 
+        ejectSpectatorsToLobby();
         try {
             if (map != null && !MapManager.unloadMap(getGameId().toString())) {
                 Pitchout.getInstance().getLogger().warning(
@@ -644,19 +667,83 @@ public class PitchoutGame extends Game {
 
     @Override
     public void removePlayer(CookiePlayer player) {
+        removePlayer(player, "left_game");
+    }
+
+    @Override
+    public synchronized void removePlayer(CookiePlayer player, String reason) {
+        if (player == null || player.getPlayer() == null) return;
+        UUID playerId = player.getPlayer().getUniqueId();
+        if (getSpectators().stream().anyMatch(viewer ->
+                viewer.getPlayer().getUniqueId().equals(playerId))) {
+            super.removePlayer(player, reason);
+            scoreboard.remove(player.getPlayer());
+            return;
+        }
         boolean wasInGame = getPlayers().contains(player);
-        super.removePlayer(player);
+        if (wasInGame && getState() == GameState.RUNNING && "disconnect".equalsIgnoreCase(reason)
+                && getPlayerLives(player) > 0) {
+            if (!disconnectedAt.containsKey(playerId)) {
+                disconnectedAt.put(playerId, System.currentTimeMillis());
+                reconnectSnapshots.put(playerId, PlayerActivitySnapshot.capture(player.getPlayer()));
+            }
+            scoreboard.remove(player.getPlayer());
+            return;
+        }
+        super.removePlayer(player, reason);
         if (!wasInGame) {
             return;
         }
         playerLives.remove(player);
-        initialSpawns.remove(player.getPlayer().getUniqueId());
+        initialSpawns.remove(playerId);
+        disconnectedAt.remove(playerId);
+        reconnectSnapshots.remove(playerId);
 
         scoreboard.remove(player.getPlayer());
         if (getState() == GameState.RUNNING) {
             checkForWinner();
         } else if (getState() == GameState.OPEN) {
             participantIds.remove(player.getPlayer().getUniqueId());
+        }
+    }
+
+    @Override
+    public boolean hasReconnectReservation(UUID playerId) {
+        Long disconnected = disconnectedAt.get(playerId);
+        return getState() == GameState.RUNNING && disconnected != null
+                && System.currentTimeMillis() - disconnected <= RECONNECT_GRACE_MILLIS
+                && playerLives.entrySet().stream().anyMatch(entry ->
+                        entry.getKey().getPlayer().getUniqueId().equals(playerId) && entry.getValue() > 0);
+    }
+
+    @Override
+    public synchronized boolean reconnect(CookiePlayer cookiePlayer) {
+        UUID playerId = cookiePlayer.getPlayer().getUniqueId();
+        CookiePlayer previous = playerLives.keySet().stream()
+                .filter(player -> player.getPlayer().getUniqueId().equals(playerId)).findFirst().orElse(null);
+        PlayerActivitySnapshot snapshot = reconnectSnapshots.get(playerId);
+        if (previous == null || snapshot == null || !hasReconnectReservation(playerId)
+                || !snapshot.relocate(cookiePlayer.getPlayer(), initialSpawns.get(playerId))
+                || !restorePlayerAfterReconnect(cookiePlayer)) {
+            return false;
+        }
+        snapshot.applyState(cookiePlayer.getPlayer());
+        int lives = playerLives.remove(previous);
+        playerLives.put(cookiePlayer, lives);
+        disconnectedAt.remove(playerId);
+        reconnectSnapshots.remove(playerId);
+        cookiePlayer.setState(PlayerState.IN_GAME);
+        return true;
+    }
+
+    private void expireReconnectReservations() {
+        long now = System.currentTimeMillis();
+        for (UUID playerId : List.copyOf(disconnectedAt.keySet())) {
+            Long disconnected = disconnectedAt.get(playerId);
+            if (disconnected == null || now - disconnected <= RECONNECT_GRACE_MILLIS) continue;
+            CookiePlayer previous = playerLives.keySet().stream()
+                    .filter(player -> player.getPlayer().getUniqueId().equals(playerId)).findFirst().orElse(null);
+            if (previous != null) removePlayer(previous, "reconnect_expired");
         }
     }
 

--- a/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
+++ b/src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java
@@ -615,10 +615,19 @@ public class PitchoutGame extends Game implements ReconnectableGame {
         }
         if (!ejectOwnedPlayersToLobby()) {
             cleanupStarted = false;
-            Pitchout.getInstance().getLogger().warning(
-                    "Deferring Pitchout map cleanup until every player reaches the lobby: " + getGameId());
-            endSequenceTask = Bukkit.getScheduler().runTaskLater(
-                    Pitchout.getInstance(), this::cleanupGameResources, 20L);
+            Pitchout plugin = Pitchout.getInstance();
+            if (plugin != null) {
+                plugin.getLogger().warning(
+                        "Deferring Pitchout map cleanup until every player reaches the lobby: " + getGameId());
+            }
+            if (plugin != null && plugin.isEnabled()) {
+                try {
+                    endSequenceTask = Bukkit.getScheduler().runTaskLater(
+                            plugin, this::cleanupGameResources, 20L);
+                } catch (RuntimeException error) {
+                    plugin.getLogger().warning("Could not schedule Pitchout cleanup retry: " + error.getMessage());
+                }
+            }
             return;
         }
 

--- a/src/main/java/com/cookiebuild/pitchout/game/ReconnectExpiryPolicy.java
+++ b/src/main/java/com/cookiebuild/pitchout/game/ReconnectExpiryPolicy.java
@@ -1,0 +1,20 @@
+package com.cookiebuild.pitchout.game;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/** Pure batch selection so simultaneous expirations are resolved before winners. */
+final class ReconnectExpiryPolicy {
+    private ReconnectExpiryPolicy() { }
+
+    static List<UUID> expired(Map<UUID, Long> disconnectedAt, long nowMillis, long graceMillis) {
+        if (disconnectedAt == null || disconnectedAt.isEmpty()) return List.of();
+        return disconnectedAt.entrySet().stream()
+                .filter(entry -> entry.getValue() != null && nowMillis - entry.getValue() > graceMillis)
+                .map(Map.Entry::getKey)
+                .sorted(Comparator.comparing(UUID::toString))
+                .toList();
+    }
+}

--- a/src/main/java/com/cookiebuild/pitchout/listeners/InGamePlayerListener.java
+++ b/src/main/java/com/cookiebuild/pitchout/listeners/InGamePlayerListener.java
@@ -237,7 +237,7 @@ public class InGamePlayerListener extends BaseEventBlocker {
                     .findFirst()
                     .orElse(null);
             if (trackedPlayer != null) {
-                pitchoutGame.removePlayer(trackedPlayer);
+                pitchoutGame.removePlayer(trackedPlayer, "disconnect");
                 break;
             }
         }

--- a/src/main/java/com/cookiebuild/pitchout/ui/PitchoutBedrockForms.java
+++ b/src/main/java/com/cookiebuild/pitchout/ui/PitchoutBedrockForms.java
@@ -40,7 +40,7 @@ public final class PitchoutBedrockForms {
         BedrockFormImages.button(form, BedrockButtonText.format(
                 Pitchout.message(player, "pitchout.form.close")), CLOSE_IMAGE);
         form.validResultHandler(response -> {
-            int index = response.getClickedButtonId();
+            int index = response.clickedButtonId();
             MainThreadPlayerAction.dispatch(plugin, player, () -> {
                 if (SESSIONS.consume(player.getUniqueId(), nonce, scope)
                         && index >= 0 && index < options.size()) voteHandler.accept(options.get(index));
@@ -67,7 +67,7 @@ public final class PitchoutBedrockForms {
         BedrockFormImages.button(form, BedrockButtonText.format(
                 Pitchout.message(player, "pitchout.form.close")), CLOSE_IMAGE);
         form.validResultHandler(response -> {
-            int index = response.getClickedButtonId();
+            int index = response.clickedButtonId();
             MainThreadPlayerAction.dispatch(plugin, player, () -> {
                 if (SESSIONS.consume(player.getUniqueId(), nonce, scope) && index == 0) replayHandler.run();
             });

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Pitchout
 version: '${version}'
 main: com.cookiebuild.pitchout.Pitchout
-api-version: '26.1.2'
+api-version: '26.2'
 load: POSTWORLD
 depend: [CookieDough]
 commands:

--- a/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
@@ -24,7 +24,7 @@ class PitchoutContinuityContractTest {
         assertTrue(source.indexOf("restorePlayerAfterReconnect(cookiePlayer)") < source.indexOf("snapshot.applyState"));
         assertTrue(removal.indexOf("getSpectators().stream()")
                 < removal.indexOf("\"disconnect\".equalsIgnoreCase(reason)"));
-        assertTrue(source.indexOf("ejectSpectatorsToLobby();")
+        assertTrue(source.indexOf("if (!ejectOwnedPlayersToLobby())")
                 < source.indexOf("MapManager.unloadMap(getGameId().toString())"));
         assertTrue(source.contains("for (CookiePlayer player : matchViewers())"));
         assertTrue(source.contains("for (CookiePlayer cookiePlayer : matchViewers())"));

--- a/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
@@ -26,6 +26,8 @@ class PitchoutContinuityContractTest {
                 < removal.indexOf("\"disconnect\".equalsIgnoreCase(reason)"));
         assertTrue(source.indexOf("if (!ejectOwnedPlayersToLobby())")
                 < source.indexOf("MapManager.unloadMap(getGameId().toString())"));
+        assertTrue(source.indexOf("plugin != null && plugin.isEnabled()")
+                < source.indexOf("this::cleanupGameResources, 20L"));
         assertTrue(source.contains("for (CookiePlayer player : matchViewers())"));
         assertTrue(source.contains("for (CookiePlayer cookiePlayer : matchViewers())"));
         assertTrue(source.contains("for (CookiePlayer spectator : getSpectators())"));

--- a/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
@@ -1,0 +1,25 @@
+package com.cookiebuild.pitchout.game;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class PitchoutContinuityContractTest {
+    @Test
+    void liveDisconnectIsReservedAndViewerCleanupPrecedesWorldUnload() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/cookiebuild/pitchout/game/PitchoutGame.java"));
+        String removal = source.substring(source.indexOf("public synchronized void removePlayer"));
+        assertTrue(source.contains("implements ReconnectableGame"));
+        assertTrue(source.contains("PlayerActivitySnapshot.capture"));
+        assertTrue(source.indexOf("snapshot.relocate") < source.indexOf("restorePlayerAfterReconnect(cookiePlayer)"));
+        assertTrue(source.indexOf("restorePlayerAfterReconnect(cookiePlayer)") < source.indexOf("snapshot.applyState"));
+        assertTrue(removal.indexOf("getSpectators().stream()")
+                < removal.indexOf("\"disconnect\".equalsIgnoreCase(reason)"));
+        assertTrue(source.indexOf("ejectSpectatorsToLobby();")
+                < source.indexOf("MapManager.unloadMap(getGameId().toString())"));
+    }
+}

--- a/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
@@ -15,6 +15,11 @@ class PitchoutContinuityContractTest {
         String removal = source.substring(source.indexOf("public synchronized void removePlayer"));
         assertTrue(source.contains("implements ReconnectableGame"));
         assertTrue(source.contains("PlayerActivitySnapshot.capture"));
+        assertTrue(source.contains("protected Location spectatorDestination"));
+        assertTrue(source.contains("reconnectExpiryBatch = true"));
+        String expiry = source.substring(source.indexOf("private void expireReconnectReservations()"),
+                source.indexOf("public int getPlayerLives"));
+        assertTrue(expiry.indexOf("reconnectExpiryBatch = false") < expiry.indexOf("checkForWinner();"));
         assertTrue(source.indexOf("snapshot.relocate") < source.indexOf("restorePlayerAfterReconnect(cookiePlayer)"));
         assertTrue(source.indexOf("restorePlayerAfterReconnect(cookiePlayer)") < source.indexOf("snapshot.applyState"));
         assertTrue(removal.indexOf("getSpectators().stream()")

--- a/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/pitchout/game/PitchoutContinuityContractTest.java
@@ -26,5 +26,8 @@ class PitchoutContinuityContractTest {
                 < removal.indexOf("\"disconnect\".equalsIgnoreCase(reason)"));
         assertTrue(source.indexOf("ejectSpectatorsToLobby();")
                 < source.indexOf("MapManager.unloadMap(getGameId().toString())"));
+        assertTrue(source.contains("for (CookiePlayer player : matchViewers())"));
+        assertTrue(source.contains("for (CookiePlayer cookiePlayer : matchViewers())"));
+        assertTrue(source.contains("for (CookiePlayer spectator : getSpectators())"));
     }
 }

--- a/src/test/java/com/cookiebuild/pitchout/game/ReconnectExpiryPolicyTest.java
+++ b/src/test/java/com/cookiebuild/pitchout/game/ReconnectExpiryPolicyTest.java
@@ -1,0 +1,25 @@
+package com.cookiebuild.pitchout.game;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+class ReconnectExpiryPolicyTest {
+    @Test
+    void returnsEverySimultaneouslyExpiredReservationAsOneBatch() {
+        UUID first = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID second = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        UUID active = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        Map<UUID, Long> disconnected = new LinkedHashMap<>();
+        disconnected.put(second, 1_000L);
+        disconnected.put(first, 1_000L);
+        disconnected.put(active, 9_500L);
+
+        assertEquals(java.util.List.of(first, second),
+                ReconnectExpiryPolicy.expired(disconnected, 10_000L, 5_000L));
+    }
+}


### PR DESCRIPTION
Adds external spectator lifecycle and short reconnect snapshots without changing participant counts or rewards.\n\nValidation: Gradle build and mode contracts green.